### PR TITLE
script type of modules needed for parcel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,6 @@
 		<title>Phaser3 + Parceljs Template</title>
 	</head>
 	<body>
-		<script src="main.ts"></script>
+		<script type="module" src="main.ts"></script>
 	</body>
 </html>


### PR DESCRIPTION
Discovered that current parcel requires a module type added to the script in index.html.